### PR TITLE
Remove Wiki from the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,7 +340,6 @@
           <div class="linkOrg-3">
             <a alt="Community on Slack" class="modernLink_Cluster" href="http://slack.btcpayserver.org/" target="blank_"><i class="fab fa-slack"></i>Slack</a>
             <a alt="Community on Github" class="modernLink_Cluster" href="https://github.com/btcpayserver" target="blank_"><i class="fab fa-github"></i>GitHub</a>
-            <a alt="BTCPay Wiki" class="modernLink_Cluster" href="https://nbitstack.com/c/btcpayserver/" target="blank_"><i class="fas fa-book-reader"></i>BTCPay Wiki</a>
             <a alt="Telegram" class="modernLink_Cluster" href="https://t.me/btcpayserver" target="blank_"><i class="fab fa-telegram"></i>Telegram</a>
           </div>
         </div>


### PR DESCRIPTION
Wiki (nbitstack) is no longer working, due to lack of community interest, so this PR removes the dead link from the website.
Close #16 