### PR TITLE
Remove Slack add Mattermost (Chat)

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@
           <h2>Join the Community</h2>
           <p>BTCPayer Server is an <b>open-source project</b>, not a company. We rely on a network of contributors and users to provide support. The project exists for and because of the community. The software has many use cases and thus the community is very diverse. Join us in improving, learning, and building BTCPay.</p>
           <div class="linkOrg-3">
-            <a alt="Community on Slack" class="modernLink_Cluster" href="http://slack.btcpayserver.org/" target="blank_"><i class="fab fa-slack"></i>Slack</a>
+            <a alt="Community on Mattermost" class="modernLink_Cluster" href="https://chat.btcpayserver.org/" target="blank_"><i class="fas fa-comments"></i></i>Chat</a>
             <a alt="Community on Github" class="modernLink_Cluster" href="https://github.com/btcpayserver" target="blank_"><i class="fab fa-github"></i>GitHub</a>
             <a alt="Telegram" class="modernLink_Cluster" href="https://t.me/btcpayserver" target="blank_"><i class="fab fa-telegram"></i>Telegram</a>
           </div>
@@ -429,7 +429,7 @@
             <h3 class="ftbTr_" id="fBTrig_-3">Community</h3>
             <ul class="ftb_" id="fBT_-3">
               <li><a alt="GitHub" href="https://github.com/btcpayserver/">GitHub</a></li>
-              <li><a alt="Slack" href="http://slack.btcpayserver.org/">Slack</a></li>
+              <li><a alt="Mattermost" href="https://chat.btcpayserver.org/">Chat</a></li>
               <li><a alt="FAQ" href="https://docs.btcpayserver.org/faq-and-common-issues/faq">FAQ</a></li>
               <li><a alt="Troubleshooting" href="https://docs.btcpayserver.org/support-and-community/troubleshooting">Troubleshooting</a></li>
               <li><a alt="Developer docs" href="https://docs.btcpayserver.org/development/">Developer docs</a></li>


### PR DESCRIPTION
This PR removes the legacy Slack community chat and adds Mattermost.
Since Mattermost is still relatively unknown, the "Chat" term is used to represent it.