### PR TITLE
Fixing the Custom Integration link in the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@
               <li><a alt="Drupal" href="https://docs.btcpayserver.org/integrations/drupal">Drupal</a></li>
               <li><a alt="Magento" href="https://docs.btcpayserver.org/integrations/drupal">Magento</a></li>
               <li><a alt="PrestaShop" href="https://docs.btcpayserver.org/integrations/drupal">PrestaShop</a></li>
-              <li><a alt="Custom Integration" href="https://docs.btcpayserver.org/integrations/drupal">Custom Integration</a></li>
+              <li><a alt="Custom Integration" href="https://docs.btcpayserver.org/integrations/customintegration">Custom Integration</a></li>
               <li><a alt="e-Shop Demo" href="https://store.demo.btcpayserver.org/">e-Shop Demo</a></li>
               <li><a alt="Point of Sale Demo" href="https://mainnet.demo.btcpayserver.org/apps/3utBTfSKkW4gK7aQMd2hW5Bh9Fpa/pos">Point of Sale Demo</a></li>
               <li><a alt="Payment Button Demo" target="blank_" href="https://store.demo.btcpayserver.org/?page_id=44">Payment Button Demo</a></li>


### PR DESCRIPTION
The Custom integration was redirecting for drupal so changed the link