### PR TITLE
Add blog to the menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
           <div class="menuContents mc_noJS" id="menuContents">
             <div class="menuLinkParent"><a alt="Features" class="menuLink" href="#modularInformationBlock"><span>Features</span></a></div>
             <div class="menuLinkParent"><a alt="Documentation" class="menuLink" target="blank_" href="http://docs.btcpayserver.org/"><span>Docs</span></a></div>
+            <div class="menuLinkParent"><a alt="Blog" class="menuLink" target="blank_" href="http://blog.btcpayserver.org/"><span>Blog</span></a></div>
             <div class="menuLinkParent"><a alt="GitHub" class="menuLink" target="blank_" href="https://github.com/btcpayserver"><span>GitHub</span></a></div>
             <div class="menuLinkParent"><a alt="Integrations" class="menuLink" href="#_Payload_5" onclick="linkToOverride(5);"><span>Integrations</span></a></div>
             <div class="menuLinkParent"><a alt="Demo" class="menuLink" href="https://mainnet.demo.btcpayserver.org/Account/Register" target="blank_"><span>Demo</span></a></div>


### PR DESCRIPTION
This PR adds BTCPay Server Official blog located at https://blog.btcpayserver.org/
It's still a modest blog, especially the front page, which will be changed after we add a little bit more content.