### PR TITLE
Add Schema.org JSON-LD Microdata for SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,50 @@
             window.noJSVideo = "Click here to open video in a new tab";
             window.closeDonationL = "close";
             window.donWor = "DONATE";
-            window.language = "en";</script></head><body><div id="p-nm-co-ho"><div class="pageContainerTopBackground __fal-right"><div class=""><div class="menuBar" id="topMarker" dir='ltr'><svg class="_Logo" onclick="window.location=\'/\'" version="1.1" id="_Logo_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="200px" height="100px" viewBox="0 0 200 100" enable-background="new 0 0 200 100" xml:space="preserve"><g><path fill="#CEDC21" d="M9.206,91.433c-2.684,0-4.859-2.177-4.859-4.861V13.431c0-2.685,2.176-4.861,4.859-4.861
+            window.language = "en";</script>
+
+    <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->
+    <script type='application/ld+json'>
+    {
+        "@context": "https://schema.org/",
+        "@type": "SoftwareApplication",
+        "applicationCategory": "FinanceApplication",
+        "name": "BTCPay Server",
+        "image": "https://btcpayserver.org/img/favicon.png",
+        "availableOnDevice": "Desktop",
+        "author": {
+        "@type": "Organization",
+        "url": "https://foundation.btcpayserver.org/",
+        "name": "BTCPay Server Foundation",
+        "sameAs": [
+        "https://twitter.com/BtcpayServer",
+        "https://t.me/btcpayserver",
+        "http://chat.btcpayserver.org/"
+	]
+        },
+        "downloadUrl": "https://github.com/btcpayserver/btcpayserver/releases",
+        "fileSize": "6MB",
+        "operatingSystem": [
+            "Windows",
+            "Linux"
+        ],
+        "releaseNotes": "https://blog.btcpayserver.org/changelog/",
+        "screenshot": "https://blog.btcpayserver.org/wp-content/uploads/2019/05/BTCPay-Invoices-1024x552.gif",
+        "softwareVersion": "1.0.3.133",
+        "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "20"
+      },
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+	"priceCurrency": "BTC"
+      }
+    }
+    </script>
+
+</head><body><div id="p-nm-co-ho"><div class="pageContainerTopBackground __fal-right"><div class=""><div class="menuBar" id="topMarker" dir='ltr'><svg class="_Logo" onclick="window.location=\'/\'" version="1.1" id="_Logo_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="200px" height="100px" viewBox="0 0 200 100" enable-background="new 0 0 200 100" xml:space="preserve"><g><path fill="#CEDC21" d="M9.206,91.433c-2.684,0-4.859-2.177-4.859-4.861V13.431c0-2.685,2.176-4.861,4.859-4.861
                             s4.86,2.177,4.86,4.861v73.141C14.066,89.256,11.89,91.433,9.206,91.433"/><path fill="#51B13E" d="M9.209,91.433c-1.818,0-3.561-1.025-4.394-2.777c-1.151-2.424-0.118-5.322,2.308-6.476L36.43,68.274
                             L6.323,46.093c-2.16-1.593-2.621-4.635-1.029-6.796s4.636-2.622,6.795-1.03l36.647,26.999c1.377,1.016,2.12,2.678,1.956,4.381
                             c-0.164,1.7-1.209,3.19-2.755,3.925L11.289,90.964C10.618,91.281,9.907,91.433,9.209,91.433"/><path fill="#CEDC21" d="M9.211,62.684c-1.493,0-2.965-0.685-3.917-1.979c-1.592-2.159-1.131-5.204,1.03-6.795L36.43,31.73

--- a/source/src/html/tmpl.html
+++ b/source/src/html/tmpl.html
@@ -26,6 +26,46 @@
             window.donWor = "$j[38]";
             window.language = "$__lang";
         </script>
+        <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->
+        <script type='application/ld+json'>
+        {
+            "@context": "https://schema.org/",
+            "@type": "SoftwareApplication",
+            "applicationCategory": "FinanceApplication",
+            "name": "BTCPay Server",
+            "image": "https://btcpayserver.org/img/favicon.png",
+            "availableOnDevice": "Desktop",
+            "author": {
+            "@type": "Organization",
+            "url": "https://foundation.btcpayserver.org/",
+            "name": "BTCPay Server Foundation",
+            "sameAs": [
+            "https://twitter.com/BtcpayServer",
+            "https://t.me/btcpayserver",
+            "http://chat.btcpayserver.org/"
+	    ]
+            },
+            "downloadUrl": "https://github.com/btcpayserver/btcpayserver/releases",
+            "fileSize": "6MB",
+            "operatingSystem": [
+                "Windows",
+                "Linux"
+            ],
+            "releaseNotes": "https://blog.btcpayserver.org/changelog/",
+            "screenshot": "https://blog.btcpayserver.org/wp-content/uploads/2019/05/BTCPay-Invoices-1024x552.gif",
+            "softwareVersion": "1.0.3.133",
+            "aggregateRating": {
+            "@type": "AggregateRating",
+            "ratingValue": "5",
+            "ratingCount": "20"
+          },
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+	    "priceCurrency": "BTC"
+          }
+        }
+        </script>
     </head>
 
     <body>


### PR DESCRIPTION
We should add schema.org microdata to BTCPay Server wbsite for a better Search Engine Optimization as specified on [https://schema.org/SoftwareApplication](https://schema.org/SoftwareApplication) and [https://developers.google.com/search/docs/data-types/software-app?hl=en](https://developers.google.com/search/docs/data-types/software-app?hl=en).

Example of a Rich Snippet inside Google's SERP (search engine result page):
![Google Rich Snippet](https://developers.google.com/search/docs/data-types/images/software-apps.png)

### What is Microdata?
Microdata (like RDFa and Microformats) is a form of semantic mark-up designed to describe elements on a web page e.g. review, person, event etc. This mark-up can be combined with typical HTML properties to dedlfine each item type through the use of associated attributes. For example, ‘Person’ has the properties name, url and title – attributes can be applied to HTML tags to describe each property.

### What is Schema.org?
Schema.org is a universally supported vocabulary extension by Google, Microsoft and Yahoo! for mark-up languages such as Microdata. It is designed to make the lives of webmasters easier, by offering one standardised mark-up understood by all the major search engines. Currently, Schema.org is compatible with Microdata, RDFa and JSON-LD.

### What is JSON-LD?
Based on the popular JSON format, the linked data format JSON-LD allows webmasters to define the context of the data contained through the use of types and properties. When combined with Schema.org, these properties follow a standardised mark-up supported by major search engines, and joins Microdata & RDFa as methods for integration. Unlike Microdata & RDFa, JSON-LD offers greater ease of implementation with all the necessary mark-up contained within inline <script> tags, instead of wrapping HTML properties. However, as elegant and lightweight that JSON-LD is, there are some potential road blocks. In some instances it’s just not practical to mark-up content, for example that on a larger scale, as the content would need to be effectively repeated within the script tags in order to validate. Also as the mark-up is invisible, the likelihood of marking up content that is not on the visible page increases, which is against search engine usage guidelines. It is for these reasons that Google in particular still favours Microdata & RDFa for marking up HTML content.

### Why use markups on BTCPay website?
Marking up content on BTCPay website can:
- Lead to the generation of rich snippets in search engine results like the one showed on top
- Enhance CTR (Click Through Rate) from the search result
- Provide greater information to search engines to improve their understanding of the content on BTCPay website

Read more about the importance of Rich Snippets: [https://yoast.com/what-are-rich-snippets/](https://yoast.com/what-are-rich-snippets/)