### PR TITLE
styles: Do not show empty tiles

### DIFF
--- a/source/src/css/styles.css
+++ b/source/src/css/styles.css
@@ -638,6 +638,7 @@ a.nonJavascriptMessage {
   cursor: col-resize;
   opacity: 0.6;
   height: 80px;
+  visibility: hidden;
 }
 
 .choice_ span {


### PR DESCRIPTION
Resolves #78. 

@vswee This needs to be tested more thoroughly, but may hide the tiles while ensuring they remain centered in the viewport.