### PR TITLE
Fix `Donate` link on footer

### DIFF
--- a/source/src/html/footer-tmpl.html
+++ b/source/src/html/footer-tmpl.html
@@ -56,7 +56,7 @@
         <a alt="$j[28]" href="https://docs.btcpayserver.org/support-and-community/contribute">$j[28]</a>
       </li>
       <li>
-        <a alt="$j[28]" href="donate">$_donate</a>
+        <a alt="$j[13]" href="donate">$j[13]</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
The `alt` tag and the title should be `Donate` instead of `Essential Apps Built-in`.
Redirection is ok BUT I discovered a 404 error if you click the link while you are already inside /donate