### PR TITLE
change donation link pavlenex

### DIFF
--- a/source/src/json/donations.json
+++ b/source/src/json/donations.json
@@ -26,7 +26,7 @@
   ],
   [
     "pavlenex",
-    "https://pavlenex.com",
+    "https://fund.btcpayserver.org/apps/3bfwsFviwBfERPQvgqFFoz4aD8RG/pos",
     "https://avatars2.githubusercontent.com/u/36959754?s=460&v=4"
   ],
   [


### PR DESCRIPTION
Changing a donation link for pavlenex since domain name is no longer in use