### PR TITLE
Fix W3C: Attribute not allowed

### DIFF
--- a/source/src/html/footer-tmpl.html
+++ b/source/src/html/footer-tmpl.html
@@ -3,20 +3,20 @@
     <h3 class="ftbTr_" id="fBTrig_-0">{{software}}</h3>
     <ul class="ftb_" id="fBT_-0">
       <li>
-        <a alt="{{introduction}}" href="https://docs.btcpayserver.org/">{{introduction}}</a>
+        <a title="{{introduction}}" href="https://docs.btcpayserver.org/">{{introduction}}</a>
       </li>
       <li>
-        <a alt="{{use-case}}" href="https://docs.btcpayserver.org/btcpay-basics/usecase">{{use-case}}</a>
+        <a title="{{use-case}}" href="https://docs.btcpayserver.org/btcpay-basics/usecase">{{use-case}}</a>
       </li>
       <li>
-        <a alt="{{apps}}"
+        <a title="{{apps}}"
           href="https://docs.btcpayserver.org/features/apps">{{apps}}</a>
       </li>
       <li>
-        <a alt="{{deployment}}" href="https://docs.btcpayserver.org/deployment/deployment">{{deployment}}</a>
+        <a title="{{deployment}}" href="https://docs.btcpayserver.org/deployment/deployment">{{deployment}}</a>
       </li>
       <li>
-        <a alt="{{getting-started}}" href="https://docs.btcpayserver.org/btcpay-basics/gettingstarted">{{getting-started}}</a>
+        <a title="{{getting-started}}" href="https://docs.btcpayserver.org/btcpay-basics/gettingstarted">{{getting-started}}</a>
       </li>
     </ul>
   </div>
@@ -33,10 +33,10 @@
         <a class="nullTrans" alt="{{github}}" href="https://github.com/btcpayserver/">{{github}}</a>
       </li>
       <li>
-        <a alt="{{support}}" href="https://docs.btcpayserver.org/support-and-community/support">{{support}}</a>
+        <a title="{{support}}" href="https://docs.btcpayserver.org/support-and-community/support">{{support}}</a>
       </li>
       <li>
-        <a alt="{{faq}}" href="https://docs.btcpayserver.org/faq-and-common-issues/faq">{{faq}}</a>
+        <a title="{{faq}}" href="https://docs.btcpayserver.org/faq-and-common-issues/faq">{{faq}}</a>
       </li>
     </ul>
   </div>
@@ -44,19 +44,19 @@
     <h3 class="ftbTr_" id="fBTrig_-3">{{community}}</h3>
     <ul class="ftb_" id="fBT_-3">
       <li>
-        <a alt="{{blog}}" href="https://blog.btcpayserver.org">{{blog}}</a>
+        <a title="{{blog}}" href="https://blog.btcpayserver.org">{{blog}}</a>
       </li>
       <li>
-        <a alt="{{chat}}" href="https://chat.btcpayserver.org">{{chat}}</a>
+        <a title="{{chat}}" href="https://chat.btcpayserver.org">{{chat}}</a>
       </li>
       <li>
-        <a alt="{{directory}}" href="https://directory.btcpayserver.org">{{directory}}</a>
+        <a title="{{directory}}" href="https://directory.btcpayserver.org">{{directory}}</a>
       </li>
       <li>
-        <a alt="{{contribute}}" href="https://docs.btcpayserver.org/support-and-community/contribute">{{contribute}}</a>
+        <a title="{{contribute}}" href="https://docs.btcpayserver.org/support-and-community/contribute">{{contribute}}</a>
       </li>
       <li>
-        <a alt="{{donate}}" href="{{_lngst}}donate">{{donate}}</a>
+        <a title="{{donate}}" href="{{_lngst}}donate">{{donate}}</a>
       </li>
     </ul>
   </div>

--- a/source/src/html/menu-tmpl.html
+++ b/source/src/html/menu-tmpl.html
@@ -74,7 +74,7 @@
             <div class="menuLinkParent mobileOnly">
                 <div class="menuLinkParent lnNomPar">
 
-                    <div id="lnNom" alt="Language" class="menuLink nullTrans" onclick="toggle_('#LanguagePicker')">
+                    <div id="lnNom" title="Language" class="menuLink nullTrans" onclick="toggle_('#LanguagePicker')">
                         <span class="nullTrans">
                             &nbsp;{{_exp0}}&nbsp;<i class="fas fa-caret-down nullTrans"></i>
                         </span>
@@ -117,7 +117,7 @@
             target="blank_">{{live-demo}}</a>&nbsp;&nbsp;&nbsp;
         <div class="menuLinkParent lnNomPar">
 
-            <div id="lnNom" alt="Language" class="menuLink nullTrans" onclick="toggle_('#LanguagePicker')">
+            <div id="lnNom" title="Language" class="menuLink nullTrans" onclick="toggle_('#LanguagePicker')">
                 <span class="nullTrans">
                     &nbsp;{{_exp0}}&nbsp;<i class="fas fa-caret-down nullTrans"></i>
                 </span>

--- a/source/src/html/tmpl.html
+++ b/source/src/html/tmpl.html
@@ -66,7 +66,7 @@
 
 			<div class="promoArea" id="promoArea">
 				<div class="promoDetails __fal-{{_rl}}">
-					<h1 alt="{{start-accepting-bitcoin}}" former_="{{start-accepting-bitcoin}}">{{start-accepting-bitcoin}}</h1>
+					<h1 title="{{start-accepting-bitcoin}}">{{start-accepting-bitcoin}}</h1>
           <p>{{btcpay-server-tag-line}}</p>
 
 					<div class="prpmpLinkOrg {{_align}}" dir="{{_to}}">


### PR DESCRIPTION
Some W3C fixes:

- Attribute **alt** not allowed on element **div** at this point. (2)
- Attribute **alt** not allowed on element **h1** at this point.
- Attribute **former_** not allowed on element **h1** at this point.
- Attribute **alt** not allowed on element **a** at this point. (16)

Attribute section (2) #133 