### PR TITLE
Fix W3C: Element source, Duplicate ID, Attribute alt

### DIFF
--- a/source/src/html/footer-tmpl.html
+++ b/source/src/html/footer-tmpl.html
@@ -24,13 +24,13 @@
     <h3 class="ftbTr_" id="fBTrig_-1">{{resources}}</h3>
     <ul class="ftb_" id="fBT_-1">
       <li class="">
-        <a class="" alt="{{documentation}}" href="https://docs.btcpayserver.org/">{{documentation}}</a>
+        <a class="" title="{{documentation}}" href="https://docs.btcpayserver.org/">{{documentation}}</a>
       </li>
       <li class="">
-        <a class="" alt="{{development}}" href="https://docs.btcpayserver.org/development">{{development}}</a>
+        <a class="" title="{{development}}" href="https://docs.btcpayserver.org/development">{{development}}</a>
       </li>
       <li class="nullTrans">
-        <a class="nullTrans" alt="{{github}}" href="https://github.com/btcpayserver/">{{github}}</a>
+        <a class="nullTrans" title="{{github}}" href="https://github.com/btcpayserver/">{{github}}</a>
       </li>
       <li>
         <a title="{{support}}" href="https://docs.btcpayserver.org/support-and-community/support">{{support}}</a>
@@ -63,7 +63,7 @@
 
 
   <p class="copyright_">
-    <a class="nullTrans" alt="Flat 18 Micro << FLAT18.CO.UK >>"
+    <a class="nullTrans" title="Flat 18 Micro << FLAT18.CO.UK >>"
       href="https://flat18.co.uk">{{website-built-with}}</a>
     <br>
     {{content-released-under}}

--- a/source/src/html/tmpl.html
+++ b/source/src/html/tmpl.html
@@ -223,16 +223,16 @@
 
 				<figure>
 					<video poster="/img/gradient.svg" class="unfetteredVideoFrame" id="unfetteredVideoFrame" playsinline controls>
-						<track src="/vtt/{{_lnstr}}.vtt" label="{{_sub}}" kind="subtitles" srclang="{{_lnstr}}" default>
 						<source src="https://btcpayserver.org/video/602.webm" type="video/webm">
 						<source src="https://btcpayserver.org/video/602.m4v" type="video/m4v">
 						<source src="https://btcpayserver.org/video/602.mp4" type="video/mp4">
+						<track src="/vtt/{{_lnstr}}.vtt" label="{{_sub}}" kind="subtitles" srclang="{{_lnstr}}" default>
 					</video>
 
 				</figure>
 			</div>
 
-			<div class="page-item-free -bg-grey" id="po0">
+			<div class="page-item-free -bg-grey">
 				<div class="pageItemInnerSpacer">
 					<div class="pageItemTextContent floatContentLeft">
 						<h2>{{docs}}</h2>


### PR DESCRIPTION
Some extra W3C fixes:
- Element **source** not allowed as child of element **video**
- Duplicate ID **po0**
- Attribute **alt** not allowed on element **a**

 Sections 2, 3 and 4 #133