### PR TITLE
Update documentation links to avoid redirects

### DIFF
--- a/source/src/html/footer-tmpl.html
+++ b/source/src/html/footer-tmpl.html
@@ -6,17 +6,17 @@
         <a title="{{introduction}}" href="https://docs.btcpayserver.org/">{{introduction}}</a>
       </li>
       <li>
-        <a title="{{use-case}}" href="https://docs.btcpayserver.org/btcpay-basics/usecase">{{use-case}}</a>
+        <a title="{{use-case}}" href="https://docs.btcpayserver.org/UseCase/">{{use-case}}</a>
       </li>
       <li>
         <a title="{{apps}}"
-          href="https://docs.btcpayserver.org/features/apps">{{apps}}</a>
+          href="https://docs.btcpayserver.org/Apps/">{{apps}}</a>
       </li>
       <li>
-        <a title="{{deployment}}" href="https://docs.btcpayserver.org/deployment/deployment">{{deployment}}</a>
+        <a title="{{deployment}}" href="https://docs.btcpayserver.org/Deployment/">{{deployment}}</a>
       </li>
       <li>
-        <a title="{{getting-started}}" href="https://docs.btcpayserver.org/btcpay-basics/gettingstarted">{{getting-started}}</a>
+        <a title="{{getting-started}}" href="https://docs.btcpayserver.org/RegisterAccount/">{{getting-started}}</a>
       </li>
     </ul>
   </div>
@@ -27,16 +27,16 @@
         <a class="" title="{{documentation}}" href="https://docs.btcpayserver.org/">{{documentation}}</a>
       </li>
       <li class="">
-        <a class="" title="{{development}}" href="https://docs.btcpayserver.org/development">{{development}}</a>
+        <a class="" title="{{development}}" href="https://docs.btcpayserver.org/Architecture/">{{development}}</a>
       </li>
       <li class="nullTrans">
         <a class="nullTrans" title="{{github}}" href="https://github.com/btcpayserver/">{{github}}</a>
       </li>
       <li>
-        <a title="{{support}}" href="https://docs.btcpayserver.org/support-and-community/support">{{support}}</a>
+        <a title="{{support}}" href="https://docs.btcpayserver.org/Support/">{{support}}</a>
       </li>
       <li>
-        <a title="{{faq}}" href="https://docs.btcpayserver.org/faq-and-common-issues/faq">{{faq}}</a>
+        <a title="{{faq}}" href="https://docs.btcpayserver.org/FAQ/">{{faq}}</a>
       </li>
     </ul>
   </div>
@@ -53,7 +53,7 @@
         <a title="{{directory}}" href="https://directory.btcpayserver.org">{{directory}}</a>
       </li>
       <li>
-        <a title="{{contribute}}" href="https://docs.btcpayserver.org/support-and-community/contribute">{{contribute}}</a>
+        <a title="{{contribute}}" href="https://docs.btcpayserver.org/Contribute/">{{contribute}}</a>
       </li>
       <li>
         <a title="{{donate}}" href="{{_lngst}}donate">{{donate}}</a>

--- a/source/src/html/tmpl.html
+++ b/source/src/html/tmpl.html
@@ -122,7 +122,7 @@
 									<p>{{features-you-use}}</p>
 									<p>{{create-a-point-of-sale}}</p>
 									<a title="{{learn-more}}" class="modernLink featuresBlockLink"
-										href="https://docs.btcpayserver.org/features/apps" target="blank_">{{learn-more}}&nbsp;&nbsp;<i
+										href="https://docs.btcpayserver.org/Apps/" target="blank_">{{learn-more}}&nbsp;&nbsp;<i
 											class="fas fa-long-arrow-alt-{{_rl}}"></i>
 									</a>
 								</div>
@@ -140,7 +140,7 @@
 									<p>{{generate-and-manage}}</p>
 									<p>{{get-notified-when}}</p>
 									<a title="{{learn-more}}" class="modernLink featuresBlockLink"
-										href="https://docs.btcpayserver.org/features/invoices" target="blank_">{{learn-more}}&nbsp;&nbsp;<i
+										href="https://docs.btcpayserver.org/Invoices/" target="blank_">{{learn-more}}&nbsp;&nbsp;<i
 											class="fas fa-long-arrow-alt-{{_rl}}"></i>
 									</a>
 								</div>
@@ -185,31 +185,31 @@
 
 					<div class="integrations-grid">
 
-						<a class="svg-link tor" href="https://docs.btcpayserver.org/faq-and-common-issues/faq-deployment#how-do-i-activate-tor-on-my-btcpay-server">
+						<a class="svg-link tor" href="https://docs.btcpayserver.org/FAQ/FAQ-Deployment/#how-do-i-activate-tor-on-my-btcpay-server">
 						<span class="tor">{{tor}}</span>
 						</a>
 
-						<a class="svg-link custom" href="https://docs.btcpayserver.org/integrations/customintegration">
+						<a class="svg-link custom" href="https://docs.btcpayserver.org/CustomIntegration/">
 						<span class="custom">{{custom-integration}}</span>
 						</a>
 
-						<a class="svg-link wp" href="https://docs.btcpayserver.org/faq-and-common-issues/faq-apps#how-to-integrate-woocommerce-store-into-a-btcpay-crowdfund-app">
+						<a class="svg-link wp" href="https://docs.btcpayserver.org/FAQ/FAQ-Apps/#how-to-integrate-woocommerce-store-into-a-btcpay-crowdfund-app">
 						<span class="wp">{{wordpress}}</span>
 						</a>
 
-						<a class="svg-link woo" href="https://docs.btcpayserver.org/integrations/woocommerce">
+						<a class="svg-link woo" href="https://docs.btcpayserver.org/WooCommerce/">
 						<span class="woo">{{woocommerce}}</span>
 						</a>
 
-						<a class="svg-link drupal" href="https://docs.btcpayserver.org/integrations/drupal">
+						<a class="svg-link drupal" href="https://docs.btcpayserver.org/Drupal/">
 						<span class="drupal">{{drupal}}</span>
 						</a>
 
 						<a class="svg-link git" href="https://github.com/btcpayserver"><span class="git">{{github}}</span></a>
 
-						<a class="svg-link mag" href="https://docs.btcpayserver.org/integrations/magento"><span class="mag">{{magento}}</span></a>
+						<a class="svg-link mag" href="https://docs.btcpayserver.org/Magento/"><span class="mag">{{magento}}</span></a>
 
-						<a class="svg-link presta" href="https://docs.btcpayserver.org/integrations/prestashop">
+						<a class="svg-link presta" href="https://docs.btcpayserver.org/PrestaShop/">
 						<span class="presta">{{prestashop}}</span>
 						</a>
 


### PR DESCRIPTION
Over time, changes have been made to the documentation and the links, the links on the official website are not updated to the new addresses but are redirected to the correct pages.

I updated the links with the new addresses to avoid redirects and improve the SEO.