### PR TITLE
change introduction footer link to Introduction, instead of docs main page

### DIFF
--- a/src/html/footer-tmpl.html
+++ b/src/html/footer-tmpl.html
@@ -3,7 +3,7 @@
     <h3 class="ftbTr_" id="fBTrig_-0">{{software}}</h3>
     <ul class="ftb_" id="fBT_-0">
       <li>
-        <a title="{{introduction}}" href="https://docs.btcpayserver.org/">{{introduction}}</a>
+        <a title="{{introduction}}" href="https://docs.btcpayserver.org/Guide/">{{introduction}}</a>
       </li>
       <li>
         <a title="{{use-case}}" href="https://docs.btcpayserver.org/UseCase/">{{use-case}}</a>


### PR DESCRIPTION
this specific page seems more introduction friendly than linking to docs main page, imo
( & the `Documentation` footer already links to docs main page)

![image](https://user-images.githubusercontent.com/93143998/191282539-c85ff981-4784-4491-8e9a-7002ad73b587.png)
