### PR TITLE
Add SmartStore integration to the integration and plugin section of the website

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -165,7 +165,7 @@ body {
 }
 .shopify {
   grid-column: 12/10;
-  grid-row: 1/7;
+  grid-row: 1/6;
 }
 .svg-link.woo::before {
   background-image: url(/img/woo.svg);
@@ -221,6 +221,15 @@ body {
 .presta {
   grid-column: 1/3;
   grid-row: 3/7;
+}
+.svg-link.smartstore::before {
+  background-image: url(/img/smartstore.svg);
+  height: 60px;
+  width: 60px;
+}
+.smartstore {
+  grid-column: 12/12;
+  grid-row: 4/8;
 }
 .alt-tooktip {
   position: absolute;

--- a/src/html/tmpl.html
+++ b/src/html/tmpl.html
@@ -224,6 +224,11 @@
 							<span class="shopify">{{shopify}}</span>
 							</a>
 
+							
+						<a class="svg-link smartstore" href="https://docs.btcpayserver.org/Smartstore/">
+							<span class="smartstore">{{smartstore}}</span>
+							</a>
+
             <a class="svg-link custom" href="https://docs.btcpayserver.org/CustomIntegration/">
 						<span class="custom">{{custom-integration}}</span>
 						</a>

--- a/src/static/img/smartstore.svg
+++ b/src/static/img/smartstore.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 -1 18 17.6" style="enable-background:new 0 -1 18 17.6;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#F7A833;}
+	.st1{fill:#307ABE;}
+	.st2{fill:#44B284;}
+	.st3{fill:#64C1C7;}
+</style>
+<g>
+	<path class="st0" d="M0.1,9.5h10.2V0.1C4.9,0.1,0.5,4.2,0.1,9.5"/>
+</g>
+<path class="st1" d="M11.2,15.2c3,0,5.4-2.4,5.4-5.4c0-3-2.4-5.4-5.4-5.4V15.2z"/>
+<path class="st2" d="M10.3,12.8c0,1.3-1.1,2.4-2.4,2.4s-2.4-1.1-2.4-2.4s1.1-2.4,2.4-2.4S10.3,11.5,10.3,12.8"/>
+<path class="st3" d="M11.2,0.1c1.9,0,3.4,1.5,3.4,3.3h-3.4V0.1z"/>
+</svg>

--- a/transifex/resources/website.json
+++ b/transifex/resources/website.json
@@ -16,6 +16,7 @@
   "live-demo": "Live Demo",
   "donate": "Donate",
   "woocommerce": "WooCommerce",
+  "smartstore": "SmartStore",
   "drupal": "Drupal",
   "magento": "Magento",
   "prestashop": "PrestaShop",


### PR DESCRIPTION
Resolves #191  Add SmartStore integration to the integration and plugin section of the website

Right now I included "smartstore": "SmartStore" to the website.json file, however my guess is that it would need to be added to all the json files in "download/website" folder under transfinex folder, so it displays properly for the different languages


![image](https://github.com/btcpayserver/btcpayserver.org/assets/47084273/5c8bdc9b-f5f6-4b54-90f0-b4bba9fc6371)
