### PR TITLE
Remove individual OpenSats donations and fix link

### DIFF
--- a/src/html/donate/tmpl.html
+++ b/src/html/donate/tmpl.html
@@ -35,20 +35,11 @@
             <h2>{{corporate-donations}}</h2>
 
             <p>{{corporate-entities-wishing}}<br>
-              <a class="cta-foundation-donation button-pri button" href="https://foundation.btcpayserver.org" target="_blank" rel="noreferrer noopener">{{btcpay-server-foundation}}&nbsp;&nbsp;<i
+              <a class="cta-foundation-donation button-pri button" href="https://foundation.btcpayserver.org/index.html#membership" target="_blank" rel="noreferrer noopener">{{btcpay-server-foundation}}&nbsp;&nbsp;<i
                 class="fas fa-chevron-{{_rl}}"></i>
               </a>
             </p>
 
-          </div>
-
-          <div>
-            <h2>{{individual-donations}}</h2>
-            <p>{{if-you-re-not}}<br>
-              <a class="cta-foundation-donation button-pri button" href="https://opensats.org/projects/btcpayserver" target="_blank" rel="noreferrer noopener">{{donate}} via OpenSats&nbsp;&nbsp;<i
-                  class="fas fa-chevron-{{_rl}}"></i>
-              </a>
-            </p>
           </div>
 
         </contents>


### PR DESCRIPTION
This PR removes the OpenSats donation option from the website to prevent users from entering a redirect loop (clicking “Donate” on OpenSats, being sent back to our site, and then redirected again to OpenSats). It also adds a better link for corporate entities sending them directly to the contact form vs the homepage of the foundaiton website.

### Before

<img width="1944" height="708" alt="Screenshot 2025-10-30 at 12 37 12" src="https://github.com/user-attachments/assets/2e8ec1c3-9d9e-499b-9c47-a6843bff3e3b" />

### After
<img width="2022" height="630" alt="Screenshot 2025-10-30 at 12 37 09" src="https://github.com/user-attachments/assets/69abc80f-3d6b-4cde-b3d2-049ada62a7f0" />
